### PR TITLE
Add GHCR release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release-docker-ghcr
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set release tag
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.RELEASE_TAG }}
+            ghcr.io/${{ github.repository }}:latest

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ MQTT_USER=user
 MQTT_PASS=changeme
 CRON=0 * * * *
 ```
+## GitHub Packages
+
+Images are automatically published to GitHub Container Registry whenever a new release is published. You can pull the latest image using:
+
+```
+docker pull ghcr.io/moafrancky/speedtest2mqtt:latest
+```
 
 ## Note
 


### PR DESCRIPTION
## Summary
- automate Docker image publishing to GHCR on release
- document GHCR images in README

## Testing
- `yamllint .github/workflows` *(fails: too many errors in existing workflow)*

------
https://chatgpt.com/codex/tasks/task_e_6855c47a4dd8832ba47727bfc66f5e34